### PR TITLE
Syncing dev with v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/habx/pg-commands
 
-go 1.14
+go 1.15
 
 require (
 	github.com/go-pg/pg v8.0.7+incompatible

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "__comment": "This is a dummy file, this shall be replaced by some habx_manifest.json one day",
-  "version": "0.1.1"
+  "version": "0.2.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
 {
   "__comment": "This is a dummy file, this shall be replaced by some habx_manifest.json one day",
-  "version": "0.1.0"
+  "version": "0.1.1"
 }


### PR DESCRIPTION
Fixes made in v0.1.1 should appear in the dev branch

-- 
_[create_release](https://github.com/habx/devops-job-release-tools) v0.16.1_
